### PR TITLE
add comments saying that link-initialize is loaded from `body`, not `head`

### DIFF
--- a/examples/go/public/index.html
+++ b/examples/go/public/index.html
@@ -19,6 +19,8 @@
         <span class="radio-button radio-right" id="liveLinkButton">Regular Mode</span>
       </div>
     </div>
+    
+     <!-- The link-initialize script is loaded from the <body>, not <head> -->
     <script src="https://cdn.plaid.com/link/stable/link-initialize.js"></script>
     <script>
     // This demo uses two custom initializers so that we can provide

--- a/examples/ruby/public/index.html
+++ b/examples/ruby/public/index.html
@@ -19,6 +19,8 @@
         <span class="radio-button radio-right" id="liveLinkButton">Regular Mode</span>
       </div>
     </div>
+    
+    <!-- The link-initialize script is loaded from the <body>, not <head> -->
     <script src="https://cdn.plaid.com/link/stable/link-initialize.js"></script>
     <script>
     // This demo uses two custom initializers so that we can provide


### PR DESCRIPTION
The example has the link-initialize script loaded in the `<body>`, but it is not explicitly mentioned that it needs to be here (as opposed to `<head>`). When it is placed in the `<head>`, a cryptic error is raised:

```
plaid-link-initialize.js:2 Uncaught TypeError: Cannot read property 'appendChild' of null
```

Searching the issues for this error finds https://github.com/plaid/link/issues/67 which recommends moving the script tag into the `<body>`. 

I think there should be a comment in the example html file which mentions this requirement explicitly. Not everyone knows to search the issues page.