### PR TITLE
Added missing comma after onLoad function

### DIFF
--- a/examples/go/public/index.html
+++ b/examples/go/public/index.html
@@ -38,7 +38,7 @@
       },
       onLoad: function() {
         console.log('Plaid Link loaded');
-      }
+      },
       onExit: function(error, metadata) {
         // if the user encountered a Plaid error, this will not be null
         if (error != null) {


### PR DESCRIPTION
Missing comma after onLoad function caused console error. Added comma to fix error. Tested and ran after adding comma to assure working code.