### PR TITLE
Fix javascript syntax due to missing comma

### DIFF
--- a/examples/ruby/public/index.html
+++ b/examples/ruby/public/index.html
@@ -67,7 +67,7 @@
       },
       onLoad: function() {
         console.log('Plaid Link loaded');
-      }
+      },
       onExit: function(error, metadata) {
         // if the user encountered a Plaid error, this will not be null
         if (error != null) {


### PR DESCRIPTION
Fixes #129

The fix merged to master fixed the missing comma on line 41 but not on line 70.

