### PR TITLE
Add a Podspec for installation from CocoaPods

### DIFF
--- a/PlaidLinkKit.podspec
+++ b/PlaidLinkKit.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name = "PlaidLinkKit"
+  s.version = "0.0.1"
+  s.summary = "A quick and secure way to integrate with the Plaid API."
+
+  s.description = <<-DESC
+    A quick and secure way to integrate with the Plaid API. Enjoy!
+  DESC
+
+  s.author = 'Plaid Technologies, Inc.'
+  s.homepage = "https://github.com/plaid/link"
+  s.license = "MIT"
+
+  s.platform     = :ios
+
+  s.source = { git: "https://github.com/plaid/link.git" }
+  s.vendored_frameworks = "ios/LinkKit.framework"
+end


### PR DESCRIPTION
This allows users to install the SDK via CocoaPods instead of manually vendoring the framework. You (Plaid) will probably want to make some edits here, and actually upload it to CocoaPods. I've simply configured it to get the actual install working.

For now, people can install from GitHub with:

```ruby
pod 'PlaidLinkKit', git: 'https://github.com/jh-digital/link.git', branch: 'cocoapods'
```

Fixes: https://github.com/plaid/link/issues/150