### PR TITLE
Use correct LinkKit.json URL for Carthage

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -109,7 +109,7 @@ To integrate [`LinkKit.framework`][linkkit] into your application using
 * Add the next line to your Cartfile:
 
 ```
-binary "https://raw.githubusercontent.com/plaid/link/carthage/LinkKit.json"
+binary "https://raw.githubusercontent.com/plaid/link/master/LinkKit.json"
 ```
 
 * Run the following command: `carthage update`


### PR DESCRIPTION
The URL that was in the README before led to a 404.