### PR TITLE
ios: Update instructions when integrating with Cocoapods

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -92,13 +92,6 @@ pod 'Plaid'
 * Run the following command:
 `pod install`
 
-* Add a **Run Script Build Phase** (we recommend naming it `Prepare for Distribution`) with the
-  [script below](#user-content-prepare-distribution-script).
-  Be sure that the `Prepare for Distribution` build phase runs _after_ the `Embed
-  Frameworks` build phase.
-  <br><img src='docs/images/setup/07-new_run_build_phase.jpg' width='350' title='Add new Run Script Build Phase'>
-  <img src='docs/images/setup/08-edit_run_build_phase.jpg' width='350' title='Editing the `Prepare for Distribution` build phase'>
-
 * To update [`LinkKit.framework`][linkkit] in the future run:
 `pod update Plaid`
 


### PR DESCRIPTION
The custom Run Script Phase is not necessary, since the
`[CP] Embed Pods Frameworks` build phase from Cocoapods
already strips unused architectures from fat libraries.

See issue #203 and https://github.com/CocoaPods/CocoaPods/blob/2fb2db21016f82806d3940013bda30ffa941151b/lib/cocoapods/generator/embed_frameworks_script.rb#L122-L138